### PR TITLE
fixed spelling & translation error for "tress" & "locatlity"

### DIFF
--- a/js/language_translations/english.js
+++ b/js/language_translations/english.js
@@ -497,7 +497,7 @@ ubsApp.translation={
         "paymentQuestion6":"Many customers want digital payment options and you need to enrol with a digital wallet provider. Enrolment fee is Rp 500",
         "paymentQuestion7":"Need to find additional help for the shop a the cost of Rp 1000",
         "paymentQuestion8":"You have to spend on printing and distributing pamphlets to promote an upcoming sale. Rp 1000",
-        "paymentQuestion9":"Pay your contribution for planting more tress in the locatlity. Rp 500",
+        "paymentQuestion9":"Pay your contribution for planting more trees in the locality. Rp 500",
         "paymentQuestion10":"Owing to increased parking space usage, the landlord has asked for Rp 5000 as additional advance for the shop rental.",
         "paymentQuestion11":"Cockroaches infested the shop via one of the goods consignment. Exterminate for Rp 800",
         "paymentQuestion12":"Your shop has been disposing garbage improperly. Hence corporation has charged a fine of Rp 1000",

--- a/js/language_translations/indonesian.js
+++ b/js/language_translations/indonesian.js
@@ -498,7 +498,7 @@ ubsApp.translation={
         "paymentQuestion6":"Banyak pelanggan menginginkan opsi pembayaran digital dan Anda perlu mendaftar dengan penyedia dompet digital. Biaya pendaftaran sebesar Rp 100 ribu",
         "paymentQuestion7":"Perlu mencari bantuan tambahan untuk toko dengan biaya Rp 200 ribu",
         "paymentQuestion8":"Anda harus menghabiskan untuk mencetak dan mendistribusikan pamflet untuk mempromosikan penjualan yang akan datang. Rp 200 ribu",
-        "paymentQuestion9":"Bayar kontribusi Anda untuk menanam lebih banyak tress di locatlity. Rp 100 ribu",
+        "paymentQuestion9":"Bayar kontribusi Anda untuk menanam lebih banyak pohon di lingkungan. Rp 100 ribu",
         "paymentQuestion10":"Karena peningkatan penggunaan lahan parkir, pemilik rumah telah meminta Rp 1 juta sebagai uang muka tambahan untuk sewa toko",
         "paymentQuestion11":"Terdapat hama kecoak di toko melalui salah satu barang pengiriman. Biaya pemusnahan hama seharga Rp 150 ribu",
         "paymentQuestion12":"Toko Anda telah membuang sampah secara tidak semestinya. Dikenakan denda sebesar Rp 200 ribu",


### PR DESCRIPTION
This pull request is for Issue 5 in the excel sheet from Cindy.
In the english.js file, the following spelling errors in paymentQuestion9 were changed:
- "tress" -> "trees"
- "locatlity" -> "locality"

In the indonesian.js, the following words in paymentQuestion9 were translated to Indonesian:
- "tress" -> "pohon"
- "locatlity" -> "lingkungan"
