### PR TITLE
Translated striked out line meaning to Bahasa

### DIFF
--- a/app/src/main/assets/www/tokoku/js/layers/scenario_layer/templates.js
+++ b/app/src/main/assets/www/tokoku/js/layers/scenario_layer/templates.js
@@ -450,7 +450,7 @@ ubsApp.leaderBoardTemplate=
 '                   </tbody>'+
 '                 </table>'+
 '               </div>'+
-'  <font size="2%"><i>* The striked out item is out of stock</font> </i>        </div>'+
+'  <font size="2%"><i>* Jika persedian barang tulisannya dicoret menendakan persedian sudah habis</font> </i>        </div>'+
 '           </div>'+
 '       </div>'+
 '       </div>'+


### PR DESCRIPTION
In **templates.js, line 453**, **"The striked out item is out of stock" is translated to Indonesian** - "Jika persedian barang tulisannya dicoret menendakan persedian sudah habis". (translation provided by Andre)

This is regarding Tester-2b Kristina's feedback that the original line is in English and not in Bahasa.